### PR TITLE
Update aframe-button-controls.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Cannot detect the button on Cardboard V1, as the magnetic sensor is not exposed 
 
 Basic use:
 ```html
-	<script src="https://unpkg.com/aframe-button-controls@^1.1.0/aframe-button-controls.js"></script>
+	<script src="https://unpkg.com/aframe-button-controls@^1.1.1/aframe-button-controls.js"></script>
 	
 	<script>
 		AFRAME.registerComponent('mystuff', {

--- a/aframe-button-controls.js
+++ b/aframe-button-controls.js
@@ -1,5 +1,5 @@
 // aframe-button-controller.js - lowest common denominator controller support for A-Frame (just buttons)
-// Copyright © 2020 by P. Douglas Reeder under the MIT License
+// Copyright © 2020-2021 by P. Douglas Reeder under the MIT License
 
 function GamepadButtonEvent (type, controllerId, index, details) {
     this.type = type;
@@ -25,6 +25,8 @@ AFRAME.registerComponent('button-controls', {
         this.emitButton0DownEvent = this.emitButtonDownEvent.bind(this, 0);
         this.emitButton1UpEvent = this.emitButtonUpEvent.bind(this, 1);
         this.emitButton1DownEvent = this.emitButtonDownEvent.bind(this, 1);
+        this.captureCardboardDown = this.captureCardboardDown.bind(this);
+        this.captureCardboardUp = this.captureCardboardUp.bind(this);
 
         let component = this;
         this.buttons = {};   // keys are controller ids, values are array of booleans
@@ -114,17 +116,20 @@ AFRAME.registerComponent('button-controls', {
                     buttons: [{pressed: false}],
                 }; // hack to get around limitations of cardboard controller;
             }
+            this.addPseudoCardboardControllerListeners();
+            sceneEl.addEventListener('enter-vr', this.addPseudoCardboardControllerListeners);
+        } else {
+            this.addSessionEventListeners();
+            sceneEl.addEventListener('enter-vr', this.addSessionEventListeners);
         }
-        
-        this.addSessionEventListeners();
-        sceneEl.addEventListener('enter-vr', this.addSessionEventListeners);
-
     },
 
     pause: function () {
         let sceneEl = this.el.sceneEl;
         if (this.data.poll) {
             sceneEl.removeEventListener('controllersupdated', this.updateControllers);
+            this.removePseudoCardboardControllerListeners();
+            sceneEl.removeEventListener('enter-vr', this.addPseudoCardboardControllerListeners);
         } else {
             this.removeSessionEventListeners();
             sceneEl.removeEventListener('enter-vr', this.addSessionEventListeners);
@@ -134,24 +139,10 @@ AFRAME.registerComponent('button-controls', {
     addSessionEventListeners: function () {
         let sceneEl = this.el.sceneEl;
         if (!sceneEl.xrSession) { return; }
-        if (this.data.poll) {
-            // normally with poll we don't use this method, but it's the only way to capture cardboard button presses.
-            sceneEl.xrSession.addEventListener('selectstart', evt => {
-                if (evt?.target?.inputSources[0]?.targetRayMode === "gaze") {
-                    this.pseudoCardboardController.buttons[0] = {pressed:true};
-                }
-            });
-            sceneEl.xrSession.addEventListener('selectend', evt => {
-                if (evt?.target?.inputSources[0]?.targetRayMode === "gaze") {
-                    this.pseudoCardboardController.buttons[0] = {pressed:false};
-                }
-            });
-        } else {
-            sceneEl.xrSession.addEventListener('selectstart', this.emitButton0DownEvent);
-            sceneEl.xrSession.addEventListener('selectend', this.emitButton0UpEvent);
-            sceneEl.xrSession.addEventListener('squeezestart', this.emitButton1DownEvent);
-            sceneEl.xrSession.addEventListener('squeezeend', this.emitButton1UpEvent);
-        }
+        sceneEl.xrSession.addEventListener('selectstart', this.emitButton0DownEvent);
+        sceneEl.xrSession.addEventListener('selectend', this.emitButton0UpEvent);
+        sceneEl.xrSession.addEventListener('squeezestart', this.emitButton1DownEvent);
+        sceneEl.xrSession.addEventListener('squeezeend', this.emitButton1UpEvent);
     },
 
     removeSessionEventListeners: function () {
@@ -179,6 +170,33 @@ AFRAME.registerComponent('button-controls', {
         this.el.emit('buttonup', new GamepadButtonEvent('buttonup', gamepad.id, buttonInd, gamepad.buttons[buttonInd]));
     },
 
+    addPseudoCardboardControllerListeners: function () {
+        let sceneEl = this.el.sceneEl;
+        if (!sceneEl.xrSession) { return; }
+        // normally with poll we don't use this method, but it's the only way to capture cardboard button presses.
+        sceneEl.xrSession.addEventListener('selectstart', this.captureCardboardDown);
+        sceneEl.xrSession.addEventListener('selectend', this.captureCardboardUp);
+    },
+
+    removePseudoCardboardControllerListeners: function () {
+        let sceneEl = this.el.sceneEl;
+        if (!sceneEl.xrSession) { return; }
+        sceneEl.xrSession.removeEventListener('selectstart', this.captureCardboardDown);
+        sceneEl.xrSession.removeEventListener('selectend', this.captureCardboardUp);
+    },
+
+    captureCardboardDown: function (evt) {
+        if (evt.target.inputSources[0].targetRayMode === "gaze") {
+            this.pseudoCardboardController.buttons[0] = {pressed:true};
+        }
+    },
+
+    captureCardboardUp: function (evt) {
+        if (evt.target.inputSources[0].targetRayMode === "gaze") {
+            this.pseudoCardboardController.buttons[0] = {pressed: false};
+        }
+    },
+
     syntheticGamepad: function (inputSource) {
         let gamepad;
         if (inputSource && inputSource.gamepad) {
@@ -186,12 +204,10 @@ AFRAME.registerComponent('button-controls', {
                 id: inputSource.gamepad.id,
                 buttons: inputSource.gamepad.buttons
             }
-        }
-        else if (inputSource.targetRayMode === "gaze") {
+        } else if (inputSource.targetRayMode === "gaze") {
             gamepad = this.pseudoCardboardController;
-        }
-        else {
-            console.warn("using hardcoded value...?")
+        } else {
+            console.warn("using hardcoded value...?");
             gamepad = {
                 buttons: [{pressed: true, value: 0.75}, {pressed: false, value: 0.25}]
             };
@@ -244,7 +260,7 @@ AFRAME.registerComponent('button-controls', {
                         for (let j=0; j<gamepad.buttons.length; ++j) {
                             let buttonPressed = gamepad.buttons[j].pressed;
                             let oldButtonPressed = component.buttons[gamepad.id][j];
-                            if (buttonPressed && !oldButtonPressed) {
+                            if (buttonPressed && ! oldButtonPressed) {
                                 component.el.emit('buttondown', new GamepadButtonEvent('buttondown', gamepad.id, j, gamepad.buttons[j]));
                             } else if (!buttonPressed && oldButtonPressed) {
                                 component.el.emit('buttonup', new GamepadButtonEvent('buttonup', gamepad.id, j, gamepad.buttons[j]));

--- a/example.html
+++ b/example.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <title>button-controls test - A-Frame</title>
     <meta name="description" content="should update when trigger pressed (or screen tapped or mouse clicked)">
-    <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.4.0/aframe.min.js"></script>
     <script src="https://unpkg.com/aframe-environment-component@^1.2.0/dist/aframe-environment-component.min.js"></script>
     <script src="aframe-button-controls.js"></script>
     <script>

--- a/example.html
+++ b/example.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <title>button-controls test - A-Frame</title>
     <meta name="description" content="should update when trigger pressed (or screen tapped or mouse clicked)">
-    <script src="https://aframe.io/releases/1.1.0/aframe.min.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@^2.0/dist/aframe-environment-component.min.js"></script>
+    <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@^1.2.0/dist/aframe-environment-component.min.js"></script>
     <script src="aframe-button-controls.js"></script>
     <script>
         AFRAME.registerComponent('button-controls-test', {
@@ -47,7 +47,7 @@
     <a-text id="sign" width=5 position="-2 1.5 -2" anchor="left" value="Message"
             material="color: darkgreen"></a-text>
 
-    <a-entity button-controls="debug: true;"></a-entity>
+    <a-entity button-controls="poll: true; debug: true;"></a-entity>
 </a-scene>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aframe-button-controls",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An A-Frame WebVR component that supports the controller functionality available everywhere - buttons. Especially useful for apps designed to be usable with Google Cardboard V2, Gear VR without a separate Controller, mobile and desktop.",
   "main": "aframe-button-controls.js",
   "scripts": {


### PR DESCRIPTION
See: issue #4 

methodology: we still primarily rely on polling when poll=true, but when poll=true we also add the `selectstart` and `selectend` listeners in and specifically listen for the `gaze` controller in those listeners; when we detect those events, we update a fake psuedo-controller record. `syntheticGamepad()` recognizes when it is getting an update from the cardboard-gaze controller, and instead of just pushing two hardcoded button values as it did before this update, it refers to this psuedo-controller record and passes that along--in this way, the psuedo-controller record is picked up within the polling loop like other controllers when poll=true.